### PR TITLE
Handle undefined event description

### DIFF
--- a/src/app/components/ImportCalendarModal.tsx
+++ b/src/app/components/ImportCalendarModal.tsx
@@ -57,7 +57,7 @@ const ImportCalendarModal: FC<Props> = ({ shifts, show, onHide }) => {
 
       const filteredShifts = importShifts.filter((shift) => {
         return !events.data.items.some((event: any) => {
-          return event.description.includes(`#${shift.activityId}`);
+          return event.description?.includes(`#${shift.activityId}`) ?? false;
         });
       });
 


### PR DESCRIPTION
Handle an undefined event description - On fetching the current event in the user's calendar, if it has an event without a description, that will lead to an error and couldn't import the calendar into the current week.

Error:
```
TypeError: Cannot read properties of undefined (reading 'includes')
    at main.dd66209b.js:2:578035
    at Array.some (<anonymous>)
    at main.dd66209b.js:2:578012
    at Array.filter (<anonymous>)
    at onClick (main.dd66209b.js:2:577987)
```